### PR TITLE
Fixing the dyld_find bug

### DIFF
--- a/macholib/MachOGraph.py
+++ b/macholib/MachOGraph.py
@@ -46,7 +46,7 @@ class MachOGraph(ObjectGraph):
                 try:
                     fn = dyld_find(filename, env=self.env,
                         executable_path=self.executable_path,
-                        loade_pathr=loader.filename)
+                        loader_path=loader.filename)
                     self.trans_table[(loader.filename, filename)] = fn
                 except ValueError:
                     return None

--- a/macholib/MachOGraph.py
+++ b/macholib/MachOGraph.py
@@ -46,7 +46,7 @@ class MachOGraph(ObjectGraph):
                 try:
                     fn = dyld_find(filename, env=self.env,
                         executable_path=self.executable_path,
-                        loader=loader.filename)
+                        loade_pathr=loader.filename)
                     self.trans_table[(loader.filename, filename)] = fn
                 except ValueError:
                     return None


### PR DESCRIPTION
There is a bug in MachOGraph.py, where the function dyld_find is invoked and a wrong argument (loader instead of loader_path, that the function takes) is being passed. This breaks py2app functionality, as that package depends on macholib.
This simple fix seems to be enough to fix that.
I know that you're not the maintainer of this package, I just want to disseminate the bugfix, maybe it somehow winds up upstream.

Cheers,
Janis